### PR TITLE
Update utils.js

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -68,7 +68,7 @@ function checkAdvertisement(peripheralId, advertisement, callback){
         debug('checking file: ' + files[i]);
         //ugly sync - rewrite ;)
         var dataBuf = fs.readFileSync(files[i]);
-          dataStr = dataBuf.toString('ascii');
+          dataStr = dataBuf.toString('utf8').replace(/[^\x00-\x7F]/g, "");
           data = JSON.parse(dataStr);
 
           if ((eirString === data.eir) && (scanResponseString === data.scanResponse)) {


### PR DESCRIPTION
Fixed a scan.js crash when a device name contains a non-ASCII character.  

It will not crash the first time you scan the network, but if you scan again, the scan.js will crash. 
SyntaxError: Unexpected token  in JSON at position 187
    at JSON.parse (<anonymous>)
    at /gattacker/lib/utils.js:72:23